### PR TITLE
docs(governance): push-guard policy + workflow indentation normalization

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -5,8 +5,9 @@ main branch
 - Allowed direct pushes: disabled
 - Allowed PR sources: develop only (enforced by pr-policy workflow + manual rule)
 - Required status checks (must pass before merge):
-  - php-ci (all jobs)
-  - pr-policy (title & source validation)
+  - php-ci (format, static analysis, tests, composer validation)
+  - pr-policy (title, branch naming, size, labels, source restriction)
+  - push-guard (ensures no direct pushes; mark required)
   - labels-sync (optional informational) – not required
 - Require branches up to date before merging: enabled
 - Required reviews: 1 (CODEOWNER @ingenioza)
@@ -21,6 +22,7 @@ develop branch
 - Required status checks:
   - php-ci
   - pr-policy
+  - (optional) push-guard (surface accidental direct pushes)
 - Required reviews: 1 (same reviewer) – may be relaxed later when team expands
 - Require branches up to date before merge: enabled
 - Dismiss stale approvals: enabled
@@ -45,6 +47,11 @@ Automation Notes
 - pr-policy workflow already blocks PRs into main unless from develop; branch rule adds redundancy.
 - labels-sync not required to avoid blocking merges due to label sync lag.
 - Stale workflow helps prune inactive feature branches once PRs closed.
+ - push-guard fails any direct push; required status check highlights violation immediately.
+
+Workflow formatting
+
+- All workflow YAML must use spaces (no tabs). If a workflow is ignored, convert tabs to 2 spaces.
 
 Maintenance
 


### PR DESCRIPTION
Adds push-guard to documented required checks, clarifies optional use on develop, and normalizes indentation (spaces) in pr-policy.yml and php-ci.yml to avoid YAML parsing edge cases.\n\nNo application code touched. Safe merge.\n\nPost-merge manual UI steps:\n1. Settings > Branches (or Rulesets) > Edit main rule: mark required checks: php-ci, PR Policy, Guard Protected Branch Direct Pushes.\n2. (Optional) Add same checks for develop (omit push-guard if you prefer).\n3. Verify new PR shows all three checks as pending before approval.\n